### PR TITLE
[network] sign in with apple 기능 추가 

### DIFF
--- a/WeekFlex/WeekFlex.xcodeproj/project.pbxproj
+++ b/WeekFlex/WeekFlex.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		9E6760C925F0BF8900436D5C /* Login.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9E6760C825F0BF8900436D5C /* Login.storyboard */; };
+		9E6760CC25F0BF9900436D5C /* LoginVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E6760CB25F0BF9900436D5C /* LoginVC.swift */; };
 		9EC0DAF825EEB9D1007D04D0 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC0DAF725EEB9D1007D04D0 /* AppDelegate.swift */; };
 		9EC0DAFA25EEB9D1007D04D0 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC0DAF925EEB9D1007D04D0 /* SceneDelegate.swift */; };
 		9EC0DAFC25EEB9D1007D04D0 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC0DAFB25EEB9D1007D04D0 /* ViewController.swift */; };
@@ -17,6 +19,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		9E6760C425F0BD0900436D5C /* WeekFlex.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WeekFlex.entitlements; sourceTree = "<group>"; };
+		9E6760C825F0BF8900436D5C /* Login.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Login.storyboard; sourceTree = "<group>"; };
+		9E6760CB25F0BF9900436D5C /* LoginVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVC.swift; sourceTree = "<group>"; };
 		9EC0DAF425EEB9D1007D04D0 /* WeekFlex.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WeekFlex.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9EC0DAF725EEB9D1007D04D0 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9EC0DAF925EEB9D1007D04D0 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -39,6 +44,31 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9E6760C525F0BF6B00436D5C /* Login */ = {
+			isa = PBXGroup;
+			children = (
+				9E6760C725F0BF7800436D5C /* ViewController */,
+				9E6760C625F0BF7100436D5C /* Storyboard */,
+			);
+			path = Login;
+			sourceTree = "<group>";
+		};
+		9E6760C625F0BF7100436D5C /* Storyboard */ = {
+			isa = PBXGroup;
+			children = (
+				9E6760C825F0BF8900436D5C /* Login.storyboard */,
+			);
+			path = Storyboard;
+			sourceTree = "<group>";
+		};
+		9E6760C725F0BF7800436D5C /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				9E6760CB25F0BF9900436D5C /* LoginVC.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
 		9EC0DAEB25EEB9D1007D04D0 = {
 			isa = PBXGroup;
 			children = (
@@ -58,6 +88,7 @@
 		9EC0DAF625EEB9D1007D04D0 /* WeekFlex */ = {
 			isa = PBXGroup;
 			children = (
+				9E6760C425F0BD0900436D5C /* WeekFlex.entitlements */,
 				9EC0DB0525EEB9D4007D04D0 /* Info.plist */,
 				9EC0DB1325EEBAED007D04D0 /* Screen */,
 				9EC0DB0E25EEBA23007D04D0 /* Global */,
@@ -106,6 +137,7 @@
 		9EC0DB1325EEBAED007D04D0 /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				9E6760C525F0BF6B00436D5C /* Login */,
 			);
 			path = Screen;
 			sourceTree = "<group>";
@@ -167,6 +199,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9E6760C925F0BF8900436D5C /* Login.storyboard in Resources */,
 				9EC0DB0425EEB9D4007D04D0 /* LaunchScreen.storyboard in Resources */,
 				9EC0DB0125EEB9D4007D04D0 /* Assets.xcassets in Resources */,
 				9EC0DAFF25EEB9D1007D04D0 /* Main.storyboard in Resources */,
@@ -184,6 +217,7 @@
 				9EC0DAFC25EEB9D1007D04D0 /* ViewController.swift in Sources */,
 				9EC0DAF825EEB9D1007D04D0 /* AppDelegate.swift in Sources */,
 				9EC0DAFA25EEB9D1007D04D0 /* SceneDelegate.swift in Sources */,
+				9E6760CC25F0BF9900436D5C /* LoginVC.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -330,6 +364,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = WeekFlex/WeekFlex.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = WFRFQ5S6AR;
 				INFOPLIST_FILE = WeekFlex/Info.plist;
@@ -349,6 +384,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = WeekFlex/WeekFlex.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = WFRFQ5S6AR;
 				INFOPLIST_FILE = WeekFlex/Info.plist;

--- a/WeekFlex/WeekFlex/Info.plist
+++ b/WeekFlex/WeekFlex/Info.plist
@@ -34,7 +34,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
+					<string>Login</string>
 				</dict>
 			</array>
 		</dict>

--- a/WeekFlex/WeekFlex/Screen/Login/Storyboard/Login.storyboard
+++ b/WeekFlex/WeekFlex/Screen/Login/Storyboard/Login.storyboard
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/WeekFlex/WeekFlex/Screen/Login/Storyboard/Login.storyboard
+++ b/WeekFlex/WeekFlex/Screen/Login/Storyboard/Login.storyboard
@@ -1,7 +1,48 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Dsi-nY-5Z8">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <scenes/>
+    <scenes>
+        <!--LoginVC-->
+        <scene sceneID="xmb-tZ-7sz">
+            <objects>
+                <viewController storyboardIdentifier="LoginVC" id="Dsi-nY-5Z8" customClass="LoginVC" customModule="WeekFlex" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ucn-9a-pIR">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Hbg-aH-Z6f">
+                                <rect key="frame" x="16" y="680" width="382" height="200"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="200" id="w7X-3J-Vrz"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="TBm-mC-6Z1"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="Hbg-aH-Z6f" secondAttribute="bottom" constant="16" id="0YZ-BQ-fQJ"/>
+                            <constraint firstItem="Hbg-aH-Z6f" firstAttribute="leading" secondItem="TBm-mC-6Z1" secondAttribute="leading" constant="16" id="9bF-gw-duT"/>
+                            <constraint firstItem="TBm-mC-6Z1" firstAttribute="trailing" secondItem="Hbg-aH-Z6f" secondAttribute="trailing" constant="16" id="Q8M-Vs-QK7"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="buttonStackView" destination="Hbg-aH-Z6f" id="cb2-TX-AdA"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="bp7-he-vtT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-323.1884057971015" y="80.357142857142847"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WeekFlex/WeekFlex/Screen/Login/ViewController/LoginVC.swift
+++ b/WeekFlex/WeekFlex/Screen/Login/ViewController/LoginVC.swift
@@ -5,25 +5,84 @@
 //  Created by 선민승 on 2021/03/04.
 //
 
+import AuthenticationServices
 import UIKit
 
 class LoginVC: UIViewController {
 
+    @IBOutlet var buttonStackView: UIStackView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        setLayout()
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    func setLayout() {
+        let button = ASAuthorizationAppleIDButton(authorizationButtonType: .signIn, authorizationButtonStyle: .black)
+        button.addTarget(self, action: #selector(handleAppleSignIn), for: .touchUpInside)
+        button.heightAnchor.constraint(equalToConstant: 44).isActive = true
+        buttonStackView.addArrangedSubview(button)
     }
-    */
+    
+    // MARK: - Method
+    
+    // Apple Login Button 눌렸을 때 액션
+    @objc func handleAppleSignIn() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+            
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
+    }
+}
 
+
+// MARK: - Extenstion : 애플 로그인 delegate
+
+extension LoginVC: ASAuthorizationControllerDelegate {
+    
+    // Apple ID 연동 성공 시
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        switch authorization.credential {
+        // Apple ID
+        case let appleIDCredential as ASAuthorizationAppleIDCredential:
+                
+            // 계정 정보 가져오기
+            let userIdentifier = appleIDCredential.user
+            let fullName = appleIDCredential.fullName
+            let email = appleIDCredential.email
+            let access_token = appleIDCredential.identityToken
+        
+            let authorization_code = appleIDCredential.authorizationCode
+
+            // 디버깅용 프린팅
+            print("User ID : \(userIdentifier)")
+            print("User Email : \(email ?? "")")
+            print("User Name : \((fullName?.givenName ?? "") + (fullName?.familyName ?? ""))")
+            
+            if let access_token = access_token,
+               let authorization_code = authorization_code {
+                print("token : \(String(decoding: access_token, as: UTF8.self))")
+                print("authorization_code : \(String(decoding: authorization_code, as: UTF8.self))")
+            }
+     
+        default:
+            break
+        }
+    }
+        
+    // Apple ID 연동 실패 시
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        // Handle error.
+    }
+}
+
+extension LoginVC: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
+    }
 }

--- a/WeekFlex/WeekFlex/Screen/Login/ViewController/LoginVC.swift
+++ b/WeekFlex/WeekFlex/Screen/Login/ViewController/LoginVC.swift
@@ -1,0 +1,29 @@
+//
+//  LoginVC.swift
+//  WeekFlex
+//
+//  Created by 선민승 on 2021/03/04.
+//
+
+import UIKit
+
+class LoginVC: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/WeekFlex/WeekFlex/Support/Delegate/AppDelegate.swift
+++ b/WeekFlex/WeekFlex/Support/Delegate/AppDelegate.swift
@@ -5,6 +5,7 @@
 //  Created by 선민승 on 2021/03/03.
 //
 
+import AuthenticationServices
 import UIKit
 
 @main
@@ -14,6 +15,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+            appleIDProvider.getCredentialState(forUserID: "") { (credentialState, error) in
+                switch credentialState {
+                case .authorized:
+                    break // The Apple ID credential is valid.
+                case .revoked, .notFound:
+                    print("revoked or notfound")
+                    break
+                default:
+                    break
+                }
+            }
         return true
     }
 

--- a/WeekFlex/WeekFlex/WeekFlex.entitlements
+++ b/WeekFlex/WeekFlex/WeekFlex.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Task 내용
- [x] xcode 설정에서 sign in with apple Capability 추가
- [x] [style] AuthenticationServices 를 통해 sign in with apple 버튼 `Login.storyboard`, `LoginVC` 에 추가 해주었음.
         - 일단 stackView를 하나 추가해서 그 stackView에 버튼을 추가해두었음.
         - 카카오톡 버튼도 추가할 예정!
- [x] VC 기능(viewDidLoad) 에 애플로그인에 필요한 delegate 추가
- [x] `app delegate` 에 `ASAuthorizationAppleIDProvider()` 추가
- [x] 서버에서 apple login 후 나오는 token으로 status pass 되는 것까지 모두 확인함!
         - **authorization code 는 최초 1회만 발급**되기 때문에, 최초 애플로그인 시도에서 authorization code 확인 후 서버에서 access_token 을 받기로 함.
         - 위플에서는 **refresh_token은 사용하지 않을 예정**이라고 함! -according to @bluayer 

## 관계된 이슈, PR : 
#1 

## 스크린샷
<img src="https://user-images.githubusercontent.com/37579661/109977633-59a07900-7d40-11eb-89cd-6aa506cb678b.png" width = 300>

## 레퍼런스
X